### PR TITLE
fix: remove support for non-matching peers

### DIFF
--- a/src/deployers/JBSuckerDeployer.sol
+++ b/src/deployers/JBSuckerDeployer.sol
@@ -7,6 +7,7 @@ import {IJBPermissions} from "@bananapus/core/src/interfaces/IJBPermissions.sol"
 import {IJBTokens} from "@bananapus/core/src/interfaces/IJBTokens.sol";
 
 import {LibClone} from "solady/src/utils/LibClone.sol";
+import {JBSucker} from "../JBSucker.sol";
 import {IJBSucker} from "./../interfaces/IJBSucker.sol";
 import {IJBSuckerDeployer} from "./../interfaces/IJBSuckerDeployer.sol";
 
@@ -33,7 +34,7 @@ abstract contract JBSuckerDeployer is JBPermissioned, IJBSuckerDeployer {
     mapping(address => bool) public override isSucker;
 
     /// @notice The singleton used to clone suckers.
-    IJBSucker public singleton;
+    JBSucker public singleton;
 
     //*********************************************************************//
     // ------------------------ internal views --------------------------- //
@@ -75,7 +76,7 @@ abstract contract JBSuckerDeployer is JBPermissioned, IJBSuckerDeployer {
     /// @notice Configure the singleton instance that is used to clone suckers.
     /// @dev Can only be called *once* by the layer specific configurator.
     /// @param _singleton The address of the singleton.
-    function configureSingleton(IJBSucker _singleton) external {
+    function configureSingleton(JBSucker _singleton) external {
         // Make sure only the configurator can call this function.
         if (msg.sender != LAYER_SPECIFIC_CONFIGURATOR) {
             revert JBSuckerDeployer_Unauthorized(msg.sender, LAYER_SPECIFIC_CONFIGURATOR);
@@ -120,6 +121,6 @@ abstract contract JBSuckerDeployer is JBPermissioned, IJBSuckerDeployer {
         isSucker[address(sucker)] = true;
 
         // Initialize the clone.
-        IJBSucker(payable(address(sucker))).initialize({peer: address(sucker), projectId: localProjectId});
+        JBSucker(payable(address(sucker))).initialize(localProjectId);
     }
 }

--- a/src/interfaces/IJBSucker.sol
+++ b/src/interfaces/IJBSucker.sol
@@ -61,7 +61,6 @@ interface IJBSucker is IERC165 {
     function addOutstandingAmountToBalance(address token) external;
     function claim(JBClaim[] calldata claims) external;
     function claim(JBClaim calldata claimData) external;
-    function initialize(uint256 projectId, address peer) external;
     function mapToken(JBTokenMapping calldata map) external payable;
     function mapTokens(JBTokenMapping[] calldata maps) external payable;
     function prepare(

--- a/test/unit/emergency.t.sol
+++ b/test/unit/emergency.t.sol
@@ -15,7 +15,6 @@ contract SuckerEmergencyTest is Test {
     address constant TOKENS = address(700);
     address constant CONTROLLER = address(900);
     address constant PROJECT = address(1000);
-    address constant PEER = address(900);
 
     function setUp() public {
         vm.label(DIRECTORY, "MOCK_DIRECTORY");
@@ -23,17 +22,16 @@ contract SuckerEmergencyTest is Test {
         vm.label(TOKENS, "MOCK_TOKENS");
         vm.label(CONTROLLER, "MOCK_CONTROLLER");
         vm.label(PROJECT, "MOCK_PROJECT");
-        vm.label(PEER, "MOCK_PEER");
     }
 
     function testHelloWorld() external {
-        _createTestSucker(1, address(900), "");
+        _createTestSucker(1, "");
     }
 
     /// @notice Ensures that if a sucker is deprecated and a claim is valid that a user can withdraw their deposit.
     function testEmergencyExitWhenDeprecated(bool setAsDeprecated, bool isValidClaim, JBClaim memory claim) external {
         uint256 projectId = 1;
-        TestSucker sucker = _createTestSucker(projectId, address(PEER), "");
+        TestSucker sucker = _createTestSucker(projectId, "");
 
         // Mock the Directory.
         vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.PROJECTS, ()), abi.encode(PROJECT));
@@ -86,7 +84,7 @@ contract SuckerEmergencyTest is Test {
         external
     {
         uint256 projectId = 1;
-        TestSucker sucker = _createTestSucker(projectId, address(PEER), "");
+        TestSucker sucker = _createTestSucker(projectId, "");
 
         // Mock the Directory.
         vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.PROJECTS, ()), abi.encode(PROJECT));
@@ -140,7 +138,7 @@ contract SuckerEmergencyTest is Test {
         vm.assume(deprecateAt + 7 days < changeDeprecationTo || changeDeprecationTo == 0);
 
         uint256 projectId = 1;
-        TestSucker sucker = _createTestSucker(projectId, address(PEER), "");
+        TestSucker sucker = _createTestSucker(projectId, "");
 
         // Mock the Directory.
         vm.mockCall(DIRECTORY, abi.encodeCall(IJBDirectory.PROJECTS, ()), abi.encode(PROJECT));
@@ -158,7 +156,7 @@ contract SuckerEmergencyTest is Test {
         sucker.setDeprecation(changeDeprecationTo);
     }
 
-    function _createTestSucker(uint256 projectId, address peer, bytes32 salt) internal returns (TestSucker) {
+    function _createTestSucker(uint256 projectId, bytes32 salt) internal returns (TestSucker) {
         // Singleton.
         TestSucker singleton = new TestSucker(
             IJBDirectory(DIRECTORY), IJBPermissions(PERMISSIONS), IJBTokens(TOKENS), JBAddToBalanceMode.MANUAL
@@ -168,7 +166,7 @@ contract SuckerEmergencyTest is Test {
         // Clone the singleton and initialize the clone.
         TestSucker sucker = TestSucker(payable(address(LibClone.cloneDeterministic(address(singleton), salt))));
         vm.label(address(sucker), "SUCKER");
-        sucker.initialize(projectId, peer);
+        sucker.initialize(projectId);
 
         return TestSucker(sucker);
     }


### PR DESCRIPTION
To prevent confusion we remove references to the peer being a different address on the remoteChain. (and added a missing natspec)