### PR TITLE
fix: set refund address to be the peer sucker address, without L2 aliasing

### DIFF
--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -198,7 +198,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         internal
     {
         uint256 nativeValue;
-        uint256 maxFeePerGas = 0.2 gwei;
+        uint256 maxFeePerGas = block.basefee;
 
         // slither-disable-next-line calls-loop
         uint256 maxSubmissionCost =
@@ -240,7 +240,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
                 to: peer(),
                 amount: amount,
                 maxGas: remoteToken.minGas,
-                gasPriceBid: 0.2 gwei,
+                gasPriceBid: maxFeePerGas,
                 data: bytes(abi.encode(maxSubmissionCostERC20, bytes("")))
             });
         } else {

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -193,7 +193,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         uint256 transportPayment,
         uint256 amount,
         bytes memory data,
-        JBRemoteToken memory /* remoteToken */
+        JBRemoteToken memory remoteToken
     )
         internal
     {
@@ -204,15 +204,28 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         uint256 maxSubmissionCost =
             ARBINBOX.calculateRetryableSubmissionFee({dataLength: data.length, baseFee: maxFeePerGas});
 
-        uint256 maxSubmissionCostERC20 =
-            ARBINBOX.calculateRetryableSubmissionFee({dataLength: 0, baseFee: maxFeePerGas});
-
-        uint256 feeTotal = maxSubmissionCost + (MESSENGER_BASE_GAS_LIMIT * maxFeePerGas);
+        // Tracks the cost for the call to the remote peer.
+        uint256 callTransportCost = maxSubmissionCost + (MESSENGER_BASE_GAS_LIMIT * maxFeePerGas);
 
         // If the token is an ERC-20, bridge it to the peer.
         if (token != JBConstants.NATIVE_TOKEN) {
-            // Split the transport payment in half for the two uses of transportPayment below.
-            transportPayment = transportPayment / 2;
+            // Calculate the cost of the ERC-20 transfer.
+            uint256 maxSubmissionCostERC20 =
+                ARBINBOX.calculateRetryableSubmissionFee({dataLength: 0, baseFee: maxFeePerGas});
+
+            uint256 tokenTransportCost = maxSubmissionCostERC20 + (remoteToken.minGas * maxFeePerGas);
+
+            // Ensure we bridge enough for gas costs on L2 side
+            if (transportPayment < callTransportCost + tokenTransportCost) {
+                revert JBArbitrumSucker_NotEnoughGas(transportPayment, callTransportCost + tokenTransportCost);
+            }
+
+            {
+                // The amount of left over transportPayment will be split over the two calls.
+                uint256 transportPaymentRemainder = (transportPayment - callTransportCost - tokenTransportCost) / 2;
+                tokenTransportCost += transportPaymentRemainder;
+                callTransportCost += transportPaymentRemainder;
+            }
 
             // Approve the tokens to be bridged.
             // slither-disable-next-line calls-loop
@@ -221,29 +234,35 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
             // Perform the ERC-20 bridge transfer.
             // slither-disable-start out-of-order-retryable
             // slither-disable-next-line calls-loop,unused-return
-            IArbL1GatewayRouter(address(GATEWAYROUTER)).outboundTransferCustomRefund{value: transportPayment}({
+            IArbL1GatewayRouter(address(GATEWAYROUTER)).outboundTransferCustomRefund{value: tokenTransportCost}({
                 token: token,
                 refundTo: msg.sender,
                 to: peer(),
                 amount: amount,
-                maxGas: MESSENGER_BASE_GAS_LIMIT,
+                maxGas: remoteToken.minGas,
                 gasPriceBid: 0.2 gwei,
                 data: bytes(abi.encode(maxSubmissionCostERC20, bytes("")))
             });
         } else {
+            // Ensure we bridge enough for gas costs on L2 side
+            if (transportPayment < callTransportCost) {
+                revert JBArbitrumSucker_NotEnoughGas(transportPayment, callTransportCost);
+            }
+
+            // If the token is the native token then we only need to do a single call.
+            // So it should use all of the transportPayment.
+            callTransportCost = transportPayment;
+
             // Otherwise, the token is the native token, and the amount will be sent as `msg.value`.
             nativeValue = amount;
         }
-
-        // Ensure we bridge enough for gas costs on L2 side
-        if (transportPayment < feeTotal) revert JBArbitrumSucker_NotEnoughGas(transportPayment, feeTotal);
 
         // Create the retryable ticket containing the merkleRoot.
         // We call unsafe as we do not want the refund address to be aliased to L2.
         // The above check is the same check that makes it `safeCreateRetryableTicket`.
 
         // slither-disable-next-line calls-loop,unused-return
-        ARBINBOX.unsafeCreateRetryableTicket{value: transportPayment + nativeValue}({
+        ARBINBOX.unsafeCreateRetryableTicket{value: callTransportCost + nativeValue}({
             to: peer(),
             l2CallValue: nativeValue,
             maxSubmissionCost: maxSubmissionCost,

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -209,9 +209,9 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
 
         // If the token is an ERC-20, bridge it to the peer.
         if (token != JBConstants.NATIVE_TOKEN) {
-            // Calculate the cost of the ERC-20 transfer.
+            // Calculate the cost of the ERC-20 transfer. (96 is the length of the abi encoded `data`)
             uint256 maxSubmissionCostERC20 =
-                ARBINBOX.calculateRetryableSubmissionFee({dataLength: 0, baseFee: maxFeePerGas});
+                ARBINBOX.calculateRetryableSubmissionFee({dataLength: 96, baseFee: maxFeePerGas});
 
             uint256 tokenTransportCost = maxSubmissionCostERC20 + (remoteToken.minGas * maxFeePerGas);
 

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -204,6 +204,9 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         uint256 maxSubmissionCost =
             ARBINBOX.calculateRetryableSubmissionFee({dataLength: data.length, baseFee: maxFeePerGas});
 
+        uint256 maxSubmissionCostERC20 =
+            ARBINBOX.calculateRetryableSubmissionFee({dataLength: 0, baseFee: maxFeePerGas});
+
         uint256 feeTotal = maxSubmissionCost + (MESSENGER_BASE_GAS_LIMIT * maxFeePerGas);
 
         // If the token is an ERC-20, bridge it to the peer.
@@ -225,8 +228,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
                 amount: amount,
                 maxGas: MESSENGER_BASE_GAS_LIMIT,
                 gasPriceBid: 0.2 gwei,
-                // Calculating this in-line saves us a staticcall to `calculateRetryableSubmissionFee`.
-                data: bytes(abi.encode(maxFeePerGas * 1400, bytes("")))
+                data: bytes(abi.encode(maxSubmissionCostERC20, bytes("")))
             });
         } else {
             // Otherwise, the token is the native token, and the amount will be sent as `msg.value`.

--- a/src/JBArbitrumSucker.sol
+++ b/src/JBArbitrumSucker.sol
@@ -203,6 +203,7 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
         // slither-disable-next-line calls-loop
         uint256 maxSubmissionCost =
             ARBINBOX.calculateRetryableSubmissionFee({dataLength: data.length, baseFee: maxFeePerGas});
+
         uint256 feeTotal = maxSubmissionCost + (MESSENGER_BASE_GAS_LIMIT * maxFeePerGas);
 
         // If the token is an ERC-20, bridge it to the peer.
@@ -224,7 +225,8 @@ contract JBArbitrumSucker is JBSucker, IJBArbitrumSucker {
                 amount: amount,
                 maxGas: MESSENGER_BASE_GAS_LIMIT,
                 gasPriceBid: 0.2 gwei,
-                data: bytes(abi.encode(maxSubmissionCost, bytes("")))
+                // Calculating this in-line saves us a staticcall to `calculateRetryableSubmissionFee`.
+                data: bytes(abi.encode(maxFeePerGas * 1400, bytes("")))
             });
         } else {
             // Otherwise, the token is the native token, and the amount will be sent as `msg.value`.

--- a/test/Fork.t.sol
+++ b/test/Fork.t.sol
@@ -62,8 +62,7 @@ contract CCIPSuckerForkedTests is TestBaseWorkflow, JBTest {
 
     // RPCs
     string ETHEREUM_SEPOLIA_RPC_URL = vm.envOr("RPC_ETHEREUM_SEPOLIA", string("https://1rpc.io/sepolia"));
-    string ARBITRUM_SEPOLIA_RPC_URL =
-        vm.envOr("RPC_ARBITRUM_SEPOLIA", string("https://arbitrum-sepolia.blockpi.network/v1/rpc/public"));
+    string ARBITRUM_SEPOLIA_RPC_URL = vm.envOr("RPC_ARBITRUM_SEPOLIA", string("https://rpc.ankr.com/arbitrum_sepolia"));
 
     //*********************************************************************//
     // ---------------------------- Setup parts -------------------------- //
@@ -415,6 +414,10 @@ contract CCIPSuckerForkedTests is TestBaseWorkflow, JBTest {
         vm.prank(rootSender);
         suckerGlobal.toRemote{value: 1 ether}(JBConstants.NATIVE_TOKEN);
 
+        // Check outbox is cleared
+        uint256 outboxBalance = suckerGlobal.outboxOf(JBConstants.NATIVE_TOKEN).balance;
+        assertEq(outboxBalance, 0);
+
         // Fees are paid but balance isn't zero (excess msg.value is returned)
         assert(rootSender.balance < 1 ether);
         assert(rootSender.balance > 0);
@@ -482,6 +485,10 @@ contract CCIPSuckerForkedTests is TestBaseWorkflow, JBTest {
         // Fees are paid but balance isn't zero (excess msg.value is returned)
         assert(rootSender.balance < 1 ether);
         assert(rootSender.balance > 0);
+
+        // Check outbox is cleared
+        uint256 outboxBalance = suckerGlobal.outboxOf(address(ccipBnM)).balance;
+        assertEq(outboxBalance, 0);
 
         // Use CCIP local to initiate the transfer on the L2
         ccipLocalSimulatorFork.switchChainAndRouteMessage(arbSepoliaFork);

--- a/test/unit/arb.t.sol
+++ b/test/unit/arb.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {IInbox} from "@arbitrum/nitro-contracts/src/bridge/IInbox.sol";
+
+contract ArbitrumTest is Test {
+    uint256 maxFeePerGas = 0.2 gwei;
+
+    function setUp() public {}
+
+    /// Pulled from ETH Arb Inbox impl: https://etherscan.io/address/0x5aed5f8a1e3607476f1f81c3d8fe126deb0afe94#code
+    function calculateRetryableSubmissionFee(uint256 dataLength, uint256 baseFee) public view returns (uint256) {
+        // Use current block basefee if baseFee parameter is 0
+        return (1400 + 6 * dataLength) * (baseFee == 0 ? block.basefee : baseFee);
+    }
+
+    function testMaxSubmissionCostZeroDataLength() public {
+        uint256 maxSubmissionCostERC20 = calculateRetryableSubmissionFee({dataLength: 0, baseFee: maxFeePerGas});
+
+        assertGt(maxSubmissionCostERC20, 0);
+        assertEq(maxSubmissionCostERC20, maxFeePerGas * 1400);
+    }
+}

--- a/test/unit/arb.t.sol
+++ b/test/unit/arb.t.sol
@@ -21,4 +21,8 @@ contract ArbitrumTest is Test {
         assertGt(maxSubmissionCostERC20, 0);
         assertEq(maxSubmissionCostERC20, maxFeePerGas * 1400);
     }
+
+    function testERC20CallDataLength() public {
+        assertEq(abi.encode(uint256(0), bytes("")).length, 96);
+    }
 }


### PR DESCRIPTION
We set the refund address to be the peer, afaik we never want to cancel a transaction and we want the peer to be the recipient of the native asset. 

We can't use `createRetryableTicket` because it would alias the peer address, which is not the same as the peer address. 

Additionally we move the `JBArbitrumSucker_NotEnoughGas` check, in the case that there is an ERC20 transfer it would otherwise compare it to an incorrect amount as the call will only have half of the `transportPayment`.